### PR TITLE
Cm post payment

### DIFF
--- a/app/models/PaymentOption.js
+++ b/app/models/PaymentOption.js
@@ -15,4 +15,24 @@ let postPaymentOption = (buyerId, paymentType, acctNumber) => {
     });
 };
 
-module.exports = { postPaymentOption };
+let getUsersPaymentOptions = (id) => {
+    return new Promise( (resolve, reject) => {
+        db.all(`SELECT * from paymentOptions where paymentOptions.buyer_id = ${id} `, function (err, payments) {
+                if (err) return reject(err);
+                resolve(payments);
+        });
+    });
+};
+
+let addPaymentToOrder = (paymentId, id) => {
+    return new Promise( (resolve, reject) => {
+        db.run(`UPDATE orders set payment_type = ${paymentId} where buyer_id = ${id} AND payment_type is NULL`, function (err) {
+                if (err) return reject(err);
+                resolve();
+        });
+    });
+};
+
+
+
+module.exports = { postPaymentOption, getUsersPaymentOptions, addPaymentToOrder };

--- a/app/models/PaymentOption.js
+++ b/app/models/PaymentOption.js
@@ -1,0 +1,18 @@
+'use strict';
+const { Database } = require('sqlite3').verbose();
+const { setActiveCustomer, getActiveCustomer } = require('../activeCustomer');
+const path = require('path');
+const dbPath = path.resolve(__dirname, '..','..', 'db','bangazon.sqlite');
+const db = new Database(dbPath);
+
+
+let postPaymentOption = (buyerId, paymentType, acctNumber) => {
+    return new Promise( (resolve, reject) => {
+        db.get(`INSERT into paymentOptions VALUES (null, ${buyerId}, ${paymentType}, ${acctNumber})`, (err, user) => {
+                if (err) return reject(err);
+                resolve(user);
+        });
+    });
+};
+
+module.exports = { postPaymentOption };

--- a/app/models/PaymentOption.js
+++ b/app/models/PaymentOption.js
@@ -15,6 +15,4 @@ let postPaymentOption = (buyerId, paymentType, acctNumber) => {
     });
 };
 
-
-
 module.exports = { postPaymentOption };

--- a/app/models/PaymentOption.js
+++ b/app/models/PaymentOption.js
@@ -8,11 +8,13 @@ const db = new Database(dbPath);
 
 let postPaymentOption = (buyerId, paymentType, acctNumber) => {
     return new Promise( (resolve, reject) => {
-        db.get(`INSERT into paymentOptions VALUES (null, ${buyerId}, ${paymentType}, ${acctNumber})`, (err, user) => {
+        db.run(`INSERT into paymentOptions VALUES (null, ${buyerId}, "${paymentType}", ${acctNumber})`, function (err) {
                 if (err) return reject(err);
-                resolve(user);
+                resolve();
         });
     });
 };
+
+
 
 module.exports = { postPaymentOption };

--- a/test/addPayment.test.js
+++ b/test/addPayment.test.js
@@ -8,18 +8,24 @@ const { assert: {property, eventually, equal, isNumber, exists, isFunction, isOb
 const { postPaymentOption } = require('../app/models/PaymentOption.js');
 const { buildPaymentsDB } = require('../db/build-db.js');
 
-
-describe('POST function', () => {
-    let testPayment = {
-        buyer_id: 49,
-        payment_option_name: "Visa",
-        account_number: "77788899"
-    }; 
-    it('should be a function', () => isFunction(postPaymentOption, "postPaymentOption is a function"));
-it('should post the payment object the user created', () => {
-    return postPaymentOption(49, "visa", 77788899).then( () => {
-        console.log("yo");
-    }
-        );
+describe('PaymentOptions', () => {
+    before( function(done) {
+        buildPaymentsDB()
+        .then( () => done()); 
+      });
+    describe('POST function', () => {
+        let testPayment = {
+            buyer_id: 49,
+            payment_option_name: "Visa",
+            account_number: "77788899"
+        }; 
+        it('should be a function', () => isFunction(postPaymentOption, "postPaymentOption is a function"));
+        it('should post the payment object the user created', () => {
+        return postPaymentOption(49, "visa", 77788899).then( () => {
+        }
+            ); 
+        });
     });
 });
+
+ 

--- a/test/addPayment.test.js
+++ b/test/addPayment.test.js
@@ -5,8 +5,10 @@ const chai = require("chai");
 const chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised);
 const { assert: {property, eventually, equal, isNumber, exists, isFunction, isObject, isEqual, deepEqual} } = require('chai');
-const { postPaymentOption } = require('../app/models/PaymentOption.js');
+const { postPaymentOption, getUsersPaymentOptions, addPaymentToOrder} = require('../app/models/PaymentOption.js');
+const { getOneOrder } = require('../app/models/Order.js');
 const { buildPaymentsDB } = require('../db/build-db.js');
+
 
 describe('PaymentOptions', () => {
     before( function(done) {
@@ -26,6 +28,23 @@ describe('PaymentOptions', () => {
             ); 
         });
     });
+    describe('GET function', () => {
+        it('should be a function', () => isFunction(getUsersPaymentOptions, "getUsersPaymentOptions is a function"));
+        it('should get the object containing users payment options', () => {
+        return getUsersPaymentOptions(2).then( () => { 
+        }
+            ); 
+        });
+    });
+    describe('POST function', () => {
+        it('should be a function', () => isFunction(addPaymentToOrder, "addPaymentToOrder is a function"));
+        it('should post the selected payment option to the customers open order', () => {
+        return addPaymentToOrder(2,2).then( () => { 
+        }
+            ); 
+        });
+    });
+
 });
 
  

--- a/test/addPayment.test.js
+++ b/test/addPayment.test.js
@@ -6,7 +6,7 @@ const chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised);
 const { assert: {property, eventually, equal, isNumber, exists, isFunction, isObject, isEqual, deepEqual} } = require('chai');
 const { postPaymentOption } = require('../app/models/PaymentOption.js');
-const { buildUsersDB } = require('../db/build-db.js');
+const { buildPaymentsDB } = require('../db/build-db.js');
 
 
 describe('POST function', () => {
@@ -14,6 +14,12 @@ describe('POST function', () => {
         buyer_id: 49,
         payment_option_name: "Visa",
         account_number: "77788899"
-    };
+    }; 
     it('should be a function', () => isFunction(postPaymentOption, "postPaymentOption is a function"));
+it('should post the payment object the user created', () => {
+    return postPaymentOption(49, "visa", 77788899).then( () => {
+        console.log("yo");
+    }
+        );
+    });
 });

--- a/test/addPayment.test.js
+++ b/test/addPayment.test.js
@@ -1,0 +1,19 @@
+'use strict';
+require('dotenv').config();
+let TIMEOUT = process.env.TIMEOUT;
+const chai = require("chai");
+const chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised);
+const { assert: {property, eventually, equal, isNumber, exists, isFunction, isObject, isEqual, deepEqual} } = require('chai');
+const { postPaymentOption } = require('../app/models/PaymentOption.js');
+const { buildUsersDB } = require('../db/build-db.js');
+
+
+describe('POST function', () => {
+    let testPayment = {
+        buyer_id: 49,
+        payment_option_name: "Visa",
+        account_number: "77788899"
+    };
+    it('should be a function', () => isFunction(postPaymentOption, "postPaymentOption is a function"));
+});


### PR DESCRIPTION
**Changes:**
- added the ability for a user to add a payment option to their account. 
- added the ability for a user to add a payment to their order. 

**Reason:** To fulfill issue #3 requirements 

**To Test/Expected Behaviors:**   
  ##  Because the ORDERS test module will overwrite the changes before you can test the payment method fucntions, you will need to go into order.test.js and comment out all of the methods with a "before."

- Open DB Browser and verify that there is an order that has a payment option as "null"

- Run ```npm test``` to run the existing tests.

- Check DB Browser and verify that there is an order that has a payment option as the passed in number(2)
