### PR TITLE
"delete menu option for product popularity"

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -81,9 +81,8 @@ let printAllCustomers = () => {//main menu
   ${magenta('4.')} Add a product to sell
   ${magenta('5.')} Update product information
   ${magenta('6.')} Delete product
-  ${magenta('7.')} See product popularity
-  ${magenta('8.')} Return to the main menu
-  ${magenta('9.')} Leave Bangazon!`);
+  ${magenta('7.')} Return to the main menu
+  ${magenta('8.')} Leave Bangazon!`);
   prompt.get([{
     name: 'choice',
     description: 'Please make a selection'
@@ -99,7 +98,7 @@ let customerMenuHandler = (err, userInput) => {//handles main menu input
       //run post payment function and return to menu
     }).catch( (err) => {
       console.log("errormagherd", err);
-    }); 
+    });
 
   } else if (userInput.choice == '2') {
     addToCartStart()//add product to shopping cart
@@ -184,14 +183,8 @@ let customerMenuHandler = (err, userInput) => {//handles main menu input
       console.log("deletable products error", err);
     })
   } else if (userInput.choice == '7') {
-    productPopPrompt()
-    .then( (productPop) => {
-      console.log('the popularity for', productPop, 'is:');
-      //run function to get popularity of entered product
-    })
-  } else if (userInput.choice == '8') {
     module.exports.displayWelcome();
-  } else if (userInput.choice == '9') {
+  } else if (userInput.choice == '8') {
     console.log('Thank you for visiting Bangazon.  Goodbye.')
     prompt.stop();
   }


### PR DESCRIPTION
Changes I made:
- deleted menu prompt and path for product popularity

Reason : That functionality is not part of our MVP.  

To test:  
- run ```npm start``` 
- select an active customer
- look at main menu that comes up, and product popularity is no longer an option
- test menu options to make sure the menu works fully for all other choice

Issue #32 